### PR TITLE
chore: add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,42 @@
+CONSUL=127.0.0.1:8500
+AMQP=amqp://admin:admin@rabbit:5672?heartbeat=10
+DATA_SOURCE=postgres://postgres:postgres@postgres:5432/webitel?application_name=call_center&sslmode=disable&connect_timeout=10&search_path=call_center
+GRPC_ADDR=127.0.0.1
+
+# ID=1
+# DEV=false
+
+# LOG_LVL=debug
+# LOG_JSON=false
+# LOG_OTEL=false
+# LOG_CONSOLE=false
+# LOG_FILE=
+
+# gRPC port (0 = random)
+# GRPC_PORT=0
+# GRPC_NETWORK=tcp
+
+# SQL_DRIVER_NAME=postgres
+# SQL_DATA_SOURCE_REPLICAS=
+# SQL_MAX_IDLE_CONNS=5
+# SQL_MAX_OPEN_CONNS=5
+# SQL_LIFETIME_MILLISECONDS=300000
+# SQL_LOG=false
+# SQL_LOG_MIN_DURATION=500ms
+# QUERY_TIMEOUT=10
+
+# WAIT_CHANNEL_CLOSE=0
+# ENABLE_OMNICHANNEL=0
+# USE_IM=false
+# BEFORE_BRIDGE_SLEEP=200ms
+# POLLING_INTERVAL=500ms
+# USE_BRIDGE_ANSWER_TIMEOUT=0
+# CID type: none | Remote-Party-ID | P-Asserted-Identity
+# RESOURCE_CID_TYPE=
+# Ignore early media: True | False | Consume | Ring Ready
+# RESOURCE_IGNORE_EARLY_MEDIA=
+
+# Client mTLS certificates
+# SERVICE_CONN_CLIENT_CA=
+# SERVICE_CONN_CLIENT_KEY=
+# SERVICE_CONN_CLIENT_CERT=


### PR DESCRIPTION
Adds a documented `.env.example` (env names from `model/config.go`; required vars uncommented, optional commented with defaults). Reference/groundwork for the env migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)