### PR TITLE
[WTEL-9895]feature(call): AI AMD result variable

### DIFF
--- a/call_manager/call.go
+++ b/call_manager/call.go
@@ -859,6 +859,10 @@ func (call *CallImpl) Stats() map[string]string {
 		vars["amd_result"] = call.amdResult
 	}
 
+	if call.amdAiResult.Result != "" {
+		vars["amd_ai_result"] = call.amdAiResult.Result
+	}
+
 	var ans int64
 	if call.acceptAt != 0 {
 		ans = call.acceptAt


### PR DESCRIPTION
- add set of `amd_ai_result` variable that enable this to after executive schema